### PR TITLE
Fix up several errors in the way Boa handled listView and listCtrl controls.

### DIFF
--- a/Companions/BaseCompanions.py
+++ b/Companions/BaseCompanions.py
@@ -622,9 +622,6 @@ class ControlDTC(DesignTimeCompanion):
         if not position: position = wx.DefaultPosition
         if not size: size = wx.DefaultSize
 
-        # change windowIDName for those controls that require a different name.
-        if self.ctrlClass.__name__ == 'ListView':
-            self.windowIdName = 'winid'
 
         dts = self.designTimeSource('wx.Point(%s, %s)'%(position.x, position.y),
           'wx.Size(%s, %s)'%(size.x, size.y))
@@ -632,10 +629,11 @@ class ControlDTC(DesignTimeCompanion):
         for param in list(dts.keys()):
             dts[param] = self.eval(dts[param])
 
+        # # change windowIDName for those controls that require a different name.
+        if self.ctrlClass.__name__ == 'ListView':
+            self.windowIdName = 'winid'
+
         dts[self.windowParentName] = self.parent
-
-
-
 
         if not self.suppressWindowId:
             dts[self.windowIdName] = self.dId

--- a/Companions/BaseCompanions.py
+++ b/Companions/BaseCompanions.py
@@ -622,6 +622,10 @@ class ControlDTC(DesignTimeCompanion):
         if not position: position = wx.DefaultPosition
         if not size: size = wx.DefaultSize
 
+        # change windowIDName for those controls that require a different name.
+        if self.ctrlClass.__name__ == 'ListView':
+            self.windowIdName = 'winid'
+
         dts = self.designTimeSource('wx.Point(%s, %s)'%(position.x, position.y),
           'wx.Size(%s, %s)'%(size.x, size.y))
 
@@ -629,6 +633,9 @@ class ControlDTC(DesignTimeCompanion):
             dts[param] = self.eval(dts[param])
 
         dts[self.windowParentName] = self.parent
+
+
+
 
         if not self.suppressWindowId:
             dts[self.windowIdName] = self.dId

--- a/Companions/Companions.py
+++ b/Companions/Companions.py
@@ -235,20 +235,13 @@ class BaseConstrFlagsDTC(HelperDTC):
                         ctrl.SetWindowStyleFlag(flagsVal)
                     except Exception as e:
                         logging.error(traceback.format_exc())
-
-                    # print('wxPython detected a problem with your style flags.\n' +
-                    #                        'Your flags are set to;\n\n' +
-                    #                        flagsSrc + '\n\n' +
-                    #                        'There can only be EXACTLY ONE mode setting style. These are;\n\n' +
-                    #                        'wx.LC_LIST, wx.LC_REPORT, wx.LC_VIRTUAL, wx.LC_ICON and wx.LC_SMALL_ICON.\n\n' +
-                    #                        'Another restriction is that you cannot set contradictory flags such as;\n\n' +
-                    #                        'wx.NO_BORDER | wx.RAISED_BORDER\n\n' +
-                    #                        'Please review your flags and try again.\n\n' +
-                    #                         'P.S.  It is possible you may get this error message and\n\n' +
-                    #                         ' you DO HAVE EXACTLY ONE STYLE. This appears to be a problem with\n\n' +
-                    #                         ' wxPython and at this stage, I cannot fix it. In that case, just \n\n' +
-                    #                         ' ignore this message and continue.'
-                    #       )
+                else:
+                    selectedStyles = flagsSrc.replace(" ", "").split("|")
+                    selectedModeStyles = set(selectedStyles).intersection(
+                        ['wx.LC_LIST', 'wx.LC_REPORT', 'wx.LC_VIRTUAL', 'wx.LC_ICON', 'wx.LC_SMALL_ICON'])
+                    selectedModeStyleCount = len(selectedModeStyles)
+                    if selectedModeStyleCount==1:
+                        ctrl.SetWindowStyleFlag(flagsVal)
             else:
                 ctrl.SetWindowStyleFlag(flagsVal)
 

--- a/Companions/Companions.py
+++ b/Companions/Companions.py
@@ -21,7 +21,10 @@ from PropEdit import PropertyEditors
 from PropEdit.Enumerations import *
 from .BaseCompanions import HelperDTC
 
-import PaletteStore, RTTI
+import PaletteStore
+
+import traceback
+import logging
 
 #---Helpers---------------------------------------------------------------------
 
@@ -226,41 +229,26 @@ class BaseConstrFlagsDTC(HelperDTC):
         flagsVal = self.eval(flagsSrc)
         ctrl = self.ownerCompn.control
         if hasattr(ctrl, 'SetWindowStyleFlag'):
-            if ctrl.ClassName == 'wxListCtrl':
-                try:
-                    ctrl.SetWindowStyleFlag(flagsVal)
-                except:
-                    # This does not work. The first parameter has to be the graphics container that the dialogue will be
-                    # displayed in (like a panel or frame) but "self" here is a list control and I do not know how to
-                    # get a reference to next level up graphic component.
-                    #
-                    # dlg = wx.MessageDialog(self,
-                    #                        'wxPython detected a problem with your style flags.\n' +
+            if ctrl.ClassName in ('wxListCtrl', 'wxListView'):
+                if '0' not in flags:
+                    try:
+                        ctrl.SetWindowStyleFlag(flagsVal)
+                    except Exception as e:
+                        logging.error(traceback.format_exc())
+
+                    # print('wxPython detected a problem with your style flags.\n' +
                     #                        'Your flags are set to;\n\n' +
                     #                        flagsSrc + '\n\n' +
-                    #                        'There can only be exactly one mode setting style. These are\n' +
+                    #                        'There can only be EXACTLY ONE mode setting style. These are;\n\n' +
                     #                        'wx.LC_LIST, wx.LC_REPORT, wx.LC_VIRTUAL, wx.LC_ICON and wx.LC_SMALL_ICON.\n\n' +
                     #                        'Another restriction is that you cannot set contradictory flags such as;\n\n' +
                     #                        'wx.NO_BORDER | wx.RAISED_BORDER\n\n' +
-                    #                        'Please review your flags and try again.',
-                    #                        'Incorrect style flags', wx.OK | wx.ICON_INFORMATION)
-                    # try:
-                    #     result = dlg.ShowModal()
-                    # finally:
-                    #     dlg.Destroy()
-                    print('wxPython detected a problem with your style flags.\n' +
-                                           'Your flags are set to;\n\n' +
-                                           flagsSrc + '\n\n' +
-                                           'There can only be EXACTLY ONE mode setting style. These are;\n\n' +
-                                           'wx.LC_LIST, wx.LC_REPORT, wx.LC_VIRTUAL, wx.LC_ICON and wx.LC_SMALL_ICON.\n\n' +
-                                           'Another restriction is that you cannot set contradictory flags such as;\n\n' +
-                                           'wx.NO_BORDER | wx.RAISED_BORDER\n\n' +
-                                           'Please review your flags and try again.\n\n' +
-                                            'P.S.  It is possible you may get this error message and\n\n' +
-                                            ' you DO HAVE EXACTLY ONE STYLE. This appears to be a problem with\n\n' +
-                                            ' wxPython and at this stage, I cannot fix it. In that case, just \n\n' +
-                                            ' ignore this message and continue.'
-                          )
+                    #                        'Please review your flags and try again.\n\n' +
+                    #                         'P.S.  It is possible you may get this error message and\n\n' +
+                    #                         ' you DO HAVE EXACTLY ONE STYLE. This appears to be a problem with\n\n' +
+                    #                         ' wxPython and at this stage, I cannot fix it. In that case, just \n\n' +
+                    #                         ' ignore this message and continue.'
+                    #       )
             else:
                 ctrl.SetWindowStyleFlag(flagsVal)
 

--- a/Companions/ListCompanions.py
+++ b/Companions/ListCompanions.py
@@ -48,6 +48,12 @@ class ListCtrlDTC(Constructors.MultiItemCtrlsConstr, WindowDTC):
             self.customPropEvaluators[name] = self.EvalImageList
         self.customPropEvaluators['ImageList'] = self.EvalImageList
 
+        # # change windowIDName for those controls that require a different name.
+        if self.ctrlClass.__name__ == 'ListView':
+            self.windowIdName = 'winid'
+            holding_list = list(self.handledConstrParams)
+            holding_list[0] = 'winid'
+            self.handledConstrParams = tuple(holding_list)
     def properties(self):
         props = WindowDTC.properties(self)
         props['Columns'] = ('NoneRoute', None, None)
@@ -169,7 +175,8 @@ class ListCtrlColumnsCDTC(CollectionDTC):
         del self.textConstrLst[idx]
 
 
-class ListViewDTC(ListCtrlDTC): pass
+# class ListViewDTC(ListCtrlDTC): pass   # orig
+class ListViewDTC(ListCtrlDTC):pass
 
 
 class TreeCtrlDTC(Constructors.MultiItemCtrlsConstr, WindowDTC):

--- a/ErrorStackFrm.py
+++ b/ErrorStackFrm.py
@@ -204,10 +204,10 @@ class ErrorStackMF(wx.Frame, Utils.FrameRestorerMixin):
             for si in err.stack:
                 siTI = tree.AppendItem(errTI, '%d: %s: %s' % (si.lineNo,
                       os.path.basename(si.file), si.line.strip()))
-                tree.SetPyData(siTI, si)
+                tree.SetItemData(siTI, si)
             if err.stack:
                 tree.SetItemHasChildren(errTI, True)
-                tree.SetPyData(errTI, err.stack[-1])
+                tree.SetItemData(errTI, err.stack[-1])
                 parsedTracebacks += 1
         return parsedTracebacks
 

--- a/Views/InspectableViews.py
+++ b/Views/InspectableViews.py
@@ -147,6 +147,14 @@ class InspectableObjectView(EditorViews.EditorView, Utils.InspectorSessionMix):
             raise DesignerError(_('%s is not defined on the Palette.')%constrPrs.class_name)
         try:
             ctrlCompnClass = PaletteMapping.compInfo[ctrlClass][1]
+            # fixup for Listview which uses a windowIdName of winid, not id.
+            if ctrlClass.__name__ == 'ListView':
+                # self.windowIdName = 'winid'
+                ctrlCompnClass.windowIdName = 'winid'
+                holding_list = list(ctrlCompnClass.handledConstrParams)
+                holding_list[0] = 'winid'
+                ctrlCompnClass.handledConstrParams = tuple(holding_list)
+                a=0
         except KeyError:
             raise DesignerError(_('%s is not defined on the Palette.')%ctrlClass.__name__)
         else:


### PR DESCRIPTION
- Changed the id to winid for the init of these controls.
- With Boa in Designer mode: only allowed updated to the model when a single mode (in the Style settings) was set and blocked all other attempts.
- With Boa in Designer mode: only allowed the user to collapse the Style selection area when exactly one mode was selected, otherwise they are presented with and error message and asked to try again.
