### PR TITLE
Fixed : Directory paths with spaces caused errors.

### DIFF
--- a/Models/PythonEditorModels.py
+++ b/Models/PythonEditorModels.py
@@ -182,7 +182,9 @@ class ModuleModel(SourceModel):
                       self.editor.erroutFrm.inputPage.GetValue()).readlines()
                 
             cwd = os.path.abspath(os.getcwd())
+            cwd = f"{cwd}"
             newCwd = os.path.dirname(os.path.abspath(filename))
+            newCwd = f"{newCwd}"
             interp = Preferences.getPythonInterpreterPath()
             basename = os.path.basename(filename)
             


### PR DESCRIPTION
If the path to the saved program (or the current working directory) contained a space, then this produced an error as the space was seen by the operating system (Window, in this case) as the end of the command and the rest of the directory path was seen as the first parameter. Of course the path cannot be found. Wrapped the paths in quotes to fix the problem.