### PR TITLE
Fix module problem that stopped Boa starting up in Ubuntu.

### DIFF
--- a/Models/PythonEditorModels.py
+++ b/Models/PythonEditorModels.py
@@ -182,9 +182,9 @@ class ModuleModel(SourceModel):
                       self.editor.erroutFrm.inputPage.GetValue()).readlines()
                 
             cwd = os.path.abspath(os.getcwd())
-            cwd = f"{cwd}"
+            # cwd1 = "\""+os.path.abspath(os.getcwd())+ "\""
             newCwd = os.path.dirname(os.path.abspath(filename))
-            newCwd = f"{newCwd}"
+            # newCwd = "\""+os.path.dirname(os.path.abspath(filename))+ "\""
             interp = Preferences.getPythonInterpreterPath()
             basename = os.path.basename(filename)
             

--- a/Palette.py
+++ b/Palette.py
@@ -16,7 +16,8 @@ print('importing Palette')
 import sys
 
 import wx
-import wx.html2
+# import wx.html2
+import webbrowser
 
 import PaletteStore
 import Help, Preferences, Utils, Plugins
@@ -264,17 +265,25 @@ class BoaFrame(wx.Frame, Utils.FrameRestorerMixin):
             Help.showMainHelp(self.paletteHelpItems['boa'])
 
     def OnWxWinHelpToolClick(self, event):
-        PyHelpBrowser = MyBrowser(None, -1,title = 'wxPython 4.2.1 Help', style=wx.DEFAULT_FRAME_STYLE )
-        PyHelpBrowser.browser.LoadURL(r"https://docs.wxpython.org/index.html")
-        PyHelpBrowser.Show()
+        webbrowser.open('https://docs.wxpython.org/index.html', new=2)
         event.Skip()
+
+        # PyHelpBrowser = MyBrowser(None, -1,title = 'wxPython 4.2.1 Help', style=wx.DEFAULT_FRAME_STYLE )
+        # PyHelpBrowser.browser.LoadURL(r"https://docs.wxpython.org/index.html")
+        # PyHelpBrowser.Show()
+        # event.Skip()
+
         # Help.showMainHelp(self.paletteHelpItems['wx'])
 
     def OnPythonHelpToolClick(self, event):
-        PyHelpBrowser = MyBrowser(None, -1,title = 'Python 3 Help', style=wx.DEFAULT_FRAME_STYLE )
-        PyHelpBrowser.browser.LoadURL(r"https://docs.python.org/3/")
-        PyHelpBrowser.Show()
+        webbrowser.open('https://docs.python.org/3/', new=2)
         event.Skip()
+
+        # PyHelpBrowser = MyBrowser(None, -1,title = 'Python 3 Help', style=wx.DEFAULT_FRAME_STYLE )
+        # PyHelpBrowser.browser.LoadURL(r"https://docs.python.org/3/")
+        # PyHelpBrowser.Show()
+        # event.Skip()
+
         ## Help.showMainHelp(self.paletteHelpItems['python'])
 
     def OnCustomHelpToolClick(self, event):

--- a/Plug-ins/PyInterpreterChooser.plug-in.py
+++ b/Plug-ins/PyInterpreterChooser.plug-in.py
@@ -259,7 +259,6 @@ class PyInterpreterChooserDlg(wx.Dialog):
 
 
 if __name__ == '__main__':
-    # app = wx.PySimpleApp()
     app = wx.App()
     dlg = PyInterpreterChooserDlg(None)
     try:


### PR DESCRIPTION

Changed : the way wxPython and Python web pages are open when you click on the Help books in the Palette. Removed wx.html2 and used webbrowser module instead.