### PR TITLE
ubuntu : Palette icons and remove a couple of error messages.

### DIFF
--- a/Config/prefs_gtk_rc.py
+++ b/Config/prefs_gtk_rc.py
@@ -25,7 +25,7 @@ edSTCFolding = False
 #-Window settings---------------------------------------------------------------
 
 # Height of the Palette window. Adjust if you use big fonts
-paletteHeights = {'tabs': 100, 'menu': 56}
+paletteHeights = {'tabs': 210, 'menu': 56}
 # Used my Mac toplevel main menu
 topMenuHeight = 0
 

--- a/Editor.py
+++ b/Editor.py
@@ -131,7 +131,7 @@ class EditorFrame(wx.Frame, Utils.FrameRestorerMixin):
     def __init__(self, parent, id, inspector, newMenu, componentPalette, app, palette):
         self._created = False
         self._init_ctrls(parent)
-        self.Show()     # test for Ubuntu
+        self.Show()     # test for Ubuntu    # Is this needed?
         self.palette = palette
         self.winConfOption = 'editor'
         self.loadDims()

--- a/EditorUtils.py
+++ b/EditorUtils.py
@@ -113,10 +113,10 @@ class EditorStatusBar(wx.StatusBar):
 
         self.historyBtnBack = wx.BitmapButton(self, -1,
               Preferences.IS.load('Images/Shared/PreviousSmall.png'),
-                  (rect.x+1, rect.y+1), (16,16))
+                  wx.Point(rect.x+1, rect.y+1), wx.Size(20, 20))
         self.historyBtnFwd = wx.BitmapButton(self, -1,
               Preferences.IS.load('Images/Shared/NextSmall.png'),
-              (rect.x+1+16, rect.y+1), (16,16))
+              (rect.x+1+16, rect.y+1), (20,20))
 
         # self.historyBtns.SetToolTip('Browse the Traceback/Error/Output window history.')
         tip = _('Browse the Traceback/Error/Output window history.')

--- a/Palette.py
+++ b/Palette.py
@@ -96,7 +96,7 @@ class BoaFrame(wx.Frame, Utils.FrameRestorerMixin):
         self.SetToolBar(self.toolBar)
 
         self.palette = wx.Notebook(id=wxID_BOAFRAMEPALETTE, name='palette',
-                                   parent=self, pos=wx.Point(0, 24), size=wx.Size(637, 23), style=0)
+                                   parent=self, pos=wx.Point(0, 24), size=wx.Size(637, 23), style=wx.NB_TOP)
 
         self._init_coll_toolBar_Tools(self.toolBar)
 


### PR DESCRIPTION
#fix size of palette so icons show.
# Adjust the size of the nav buttons in the statusbar of the Editor so they don't create error messages in the console. They still don't show the image in the button. Also need to test this in Windows.